### PR TITLE
增加 docker 部署支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:lts-alpine
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install \
+    && npm run build
+
+EXPOSE 24444
+
+CMD ["node", "/app/dist/app.js"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,31 @@ exit
 
 <br />
 
+## Docker 部署
+
+拉取代码并构建镜像
+
+```console
+$ git clone https://github.com/MCSManager/Daemon
+$ cd Daemon
+$ docker build -t mcs-daemon .
+```
+
+运行
+
+```console
+$ docker run -d \
+    --name mcs-daemon \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $(pwd)/data:/app/data \
+    -p 24444:24444 \
+    mcs-daemon
+```
+
+> 必须将 `/var/run/docker.sock` 映射至容器内才能正常使用 docker 实例
+
+<br />
+
 ## 贡献
 
 如果你在使用过程中发现任何问题，可以提交 Issue 或自行 Fork 修改后提交 Pull Request。

--- a/src/entity/commands/docker/docker _start.ts
+++ b/src/entity/commands/docker/docker _start.ts
@@ -202,7 +202,9 @@ export default class DockerStartCommand extends InstanceCommand {
       logger.info(`工作目录: ${cwd}`);
       logger.info(`网络模式: ${instance.config.docker.networkMode}`);
       logger.info(`端口映射: ${JSON.stringify(publicPortArray)}`);
-      if(extraBinds.length > 0)
+      if (instance.config.docker.workspaceVolumes !== "")
+        logger.info(`Docker 挂载工作目录: ${instance.config.docker.workspaceVolumes}`);
+      if (extraBinds.length > 0)
         logger.info(`额外挂载: ${JSON.stringify(extraBinds)}`);
       logger.info(`网络别名: ${JSON.stringify(instance.config.docker.networkAliases)}`);
       if (maxMemory) logger.info(`内存限制: ${maxMemory} MB`);
@@ -226,7 +228,7 @@ export default class DockerStartCommand extends InstanceCommand {
         ExposedPorts: exposedPorts,
         HostConfig: {
           Memory: maxMemory,
-          Binds: [`${cwd}:/workspace/`, ...extraBinds],
+          Binds: [`${instance.config.docker.workspaceVolumes || cwd}:/workspace/`, ...extraBinds],
           AutoRemove: true,
           CpusetCpus: cpusetCpus,
           CpuPeriod: cpuPeriod,

--- a/src/entity/instance/Instance_config.ts
+++ b/src/entity/instance/Instance_config.ts
@@ -55,6 +55,7 @@ export default class InstanceConfig {
     containerName: "",
     image: "",
     ports: [],
+    workspaceVolumes: "",
     extraVolumes: [],
     memory: null,
     networkMode: "bridge",

--- a/src/entity/instance/interface.ts
+++ b/src/entity/instance/interface.ts
@@ -27,6 +27,7 @@ export interface IDockerConfig {
   image: string;
   memory: number; //以字节为单位的内存限制。
   ports: string[];
+  workspaceVolumes: string, //宿主机工作目录，当 daemon 处于容器中时指定
   extraVolumes: string[];
   maxSpace: number;
   network: number;


### PR DESCRIPTION
增加 Dockerfile 文件并且添加选项修复 #14 所表述的挂载路径会不一致的问题。

选项含义：
当 daemon 处于 docker 容器中时，容器中的工作目录路径和宿主机中挂载出来的路径不一定一致，通过设置该选项，使用宿主机中实际路径进实例的容器。

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/10807435/153754081-bdcec185-18c1-4f9f-88cb-a8d7f415355d.png">
