### PR TITLE
删除 docker的win32检测

### DIFF
--- a/src/routers/environment_router.ts
+++ b/src/routers/environment_router.ts
@@ -30,7 +30,6 @@ import os from "os";
 
 // 获取本系统镜像列表
 routerApp.on("environment/images", async (ctx, data) => {
-  if (os.platform() === "win32") return protocol.responseError(ctx, "[Unsupported] Windows 系统暂不支持此功能");
   try {
     const docker = new DockerManager().getDocker();
     const result = await docker.listImages();
@@ -53,7 +52,6 @@ routerApp.on("environment/containers", async (ctx, data) => {
 
 // 获取本系统网络列表
 routerApp.on("environment/networkModes", async (ctx, data) => {
-  if (os.platform() === "win32") return protocol.responseError(ctx, "[Unsupported] Windows 系统暂不支持此功能");
   try {
     const docker = new DockerManager().getDocker();
     const result = await docker.listNetworks();
@@ -65,7 +63,6 @@ routerApp.on("environment/networkModes", async (ctx, data) => {
 
 // 创建镜像
 routerApp.on("environment/new_image", async (ctx, data) => {
-  if (os.platform() === "win32") return protocol.responseError(ctx, "[Unsupported] Windows 系统暂不支持此功能");
   try {
     const dockerFileText = data.dockerFile;
     const name = data.name;


### PR DESCRIPTION
经[测试](https://github.com/MCSManager/MCSManager/issues/574#issuecomment-1185117758)，Docker for Windows 已经可以正常使用

故删除平台检测，让守护进程能直接在Windows下执行docker操作