### PR TITLE
修复 TXT配置文件类型无法写入空的BUG

### DIFF
--- a/src/entity/instance/process_config.ts
+++ b/src/entity/instance/process_config.ts
@@ -59,7 +59,7 @@ export class ProcessConfig {
     if (this.iProcessConfig.type === "txt") {
       text = object.toString();
     }
-    if (!text) throw new Error($t("process_config.writEmpty"));
+    if (!text && this.iProcessConfig.type !== "txt") throw new Error($t("process_config.writEmpty"));
     fs.writeFileSync(this.iProcessConfig.path, text, { encoding: CONFIG_FILE_ENCODE });
   }
 


### PR DESCRIPTION
当配置文件类型为TXT时，可能会写入空数据（清空配置）。